### PR TITLE
Added workflow to automatically publish to PyPI on GH release

### DIFF
--- a/.github/workflows/deploy-workflow.yml
+++ b/.github/workflows/deploy-workflow.yml
@@ -1,0 +1,31 @@
+name: Publish to PyPI
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-n-publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        name: Check out source-code repository
+
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.9
+
+      - name: Install python dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          pip install .
+
+      - name: Build the distribution
+        run: python setup.py sdist bdist_wheel
+
+      - name: Publish dist to PyPI
+        if: github.repository == 'ScilifelabDataCentre/DS_CLI'
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
This workflow automatically builds and publishes the package to the Python Package Index (PyPI) when a new release is created on GitHub.

You'll need to create a repository secret with the name `pypi_password`. See https://github.com/pypa/gh-action-pypi-publish