### PR TITLE
Black doesn't support Python 3.9 yet

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [tool.black]
 line-length = 120
-target_version = ['py36','py37','py38','py39']
+target_version = ['py36','py37','py38']


### PR DESCRIPTION
I was a bit ahead of myself in adding Python 3.9 for the Black style yet: https://github.com/ScilifelabDataCentre/DS_CLI/runs/2501903983#step:4:11