### PR TITLE
Readme typo in dev installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # SciLifeLab Data Delivery Service - Command line interface
 
-This tool adds a new terminal command `dds` which you can use to manage data and projects in the SciLifeLab Data Delivery Service over the command line.
-
-This will be used for data delivery within larger projects and/or projects resulting in the production of large amounts of data, for example next-generation sequencing data.
-
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![install with PyPI](https://img.shields.io/badge/install%20with-PyPI-blue.svg)](https://pypi.org/project/dds-cli/)
+
+> **A command line tool `dds` to manage data and projects in the SciLifeLab Data Delivery Service.**
+
+This will be used for data delivery within larger projects and/or projects resulting in the production of large amounts of data, for example next-generation sequencing data and imaging.
+
+This tool is written and maintained by the [SciLifeLab Data Centre](https://www.scilifelab.se/data).
 
 ## Table of contents
 
@@ -16,7 +18,7 @@ This will be used for data delivery within larger projects and/or projects resul
 
 ### Python Package Index
 
-> :warning: Coming soon after first release
+> :warning: Not available yet - coming soon after first release :warning:
 
 The `dds-cli` package can be installed from [PyPI](https://pypi.python.org/pypi/dds-cli/) using pip as follows:
 
@@ -29,7 +31,7 @@ pip install dds-cli
 If you would like the latest development version of tools, the command is:
 
 ```bash
-pip install --upgrade --force-reinstall git+https://github.com/nScilifelabDataCentre/DS_CLI.git@dev
+pip install --upgrade --force-reinstall git+https://github.com/ScilifelabDataCentre/DS_CLI.git@dev
 ```
 
 If you intend to make edits to the code, first make a fork of the repository and then clone it locally.
@@ -41,7 +43,7 @@ pip install --upgrade -r requirements-dev.txt -e .
 
 ## Overview of commands
 
-This package adds a tool `dds` on the command line which has the following subcommands:
+Once installed you can use the command `dds` in a terminal session. This has the following subcommands:
 
 * `get` - Download specified files from the cloud and restore the original format.
 * `ls` - List the projects and the files within projects.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SciLifeLab Data Delivery Service - Command line interface
+# SciLifeLab Data Delivery System - Command line interface
 
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![install with PyPI](https://img.shields.io/badge/install%20with-PyPI-blue.svg)](https://pypi.org/project/dds-cli/)

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open("requirements.txt") as f:
 setup(
     name="dds-cli",
     version=version,
-    description="A command line tool to manage data and projects in the SciLifeLab Data Delivery Service.",
+    description="A command line tool to manage data and projects in the SciLifeLab Data Delivery System.",
     long_description=readme,
     long_description_content_type="text/markdown",
     url="https://github.com/ScilifelabDataCentre/DS_CLI",

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open("requirements.txt") as f:
 setup(
     name="dds-cli",
     version=version,
-    description="Data Delivery Service - Command line tool",
+    description="A command line tool to manage data and projects in the SciLifeLab Data Delivery Service.",
     long_description=readme,
     long_description_content_type="text/markdown",
     url="https://github.com/ScilifelabDataCentre/DS_CLI",


### PR DESCRIPTION
I noticed a copy+paste typo in the `dev` installation command that I added last night. Fixed here.

I also rephrased some of the text now that I came back to it with fresh eyes.